### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/test-brain_palettes.R
+++ b/tests/testthat/test-brain_palettes.R
@@ -7,9 +7,8 @@ test_that("Check that palette extraction happens ok", {
   expect_equal(length(brain_pal("aseg", n=1:8)), 8)
   expect_equal(length(brain_pal("aseg", "all")), 45)
 
-  expect_warning(length(brain_pal("aseg", 2)), 3)
+  expect_warning(length(brain_pal("aseg", 2)), "3")
   expect_equal(length(brain_pal("aseg", 22, unname=TRUE)), 22)
   expect_warning(brain_pal("dk",50))
   expect_error(brain_pal("yeo"))
 })
-


### PR DESCRIPTION
`expect_warning()` now checks that the message is a string.