### PR TITLE
Remove unused stk_x variable

### DIFF
--- a/R/adapt_scales.R
+++ b/R/adapt_scales.R
@@ -62,7 +62,6 @@ adapt_scales_cortical <- function(geobrain, position, aesthetics) {
 #' @noRd
 adapt_scales_subcortical <- function(geobrain, position, aesthetics) {
   stk_y <- dplyr::summarise(dplyr::group_by(geobrain, view), val = gap(.lat))
-  stk_x <- dplyr::summarise(dplyr::group_by(geobrain, view), val = gap(.long))
   disp <- dplyr::summarise_at(
     dplyr::group_by(geobrain, view),
     dplyr::vars(.long, .lat), list(gap)


### PR DESCRIPTION
## Summary
- Remove unused `stk_x` variable in `adapt_scales_subcortical()` that was flagged by lintr's `object_usage_linter`

## Test plan
- [ ] code-quality CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)