### PR TITLE
ci: add update-codemeta workflow

### DIFF
--- a/.github/workflows/update-codemeta.yaml
+++ b/.github/workflows/update-codemeta.yaml
@@ -1,0 +1,45 @@
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - DESCRIPTION
+      - .github/workflows/update-codemeta.yaml
+  workflow_dispatch:
+
+name: update-codemeta
+
+permissions: read-all
+
+jobs:
+  update-codemeta:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    permissions:
+      contents: write
+
+    if: "!contains(github.event.head_commit.message, 'cm-skip')"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::codemetar, local::.
+
+      - name: Update codemeta.json
+        run: codemetar::write_codemeta()
+        shell: Rscript {0}
+
+      - name: Commit and push
+        if: github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add codemeta.json
+          git diff --staged --quiet || (git commit -m "Update codemeta.json" && git push)


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that regenerates `codemeta.json` automatically whenever `DESCRIPTION` changes on the default branch, using `codemetar::write_codemeta()` via `r-lib/actions`.

`codemeta.json` already exists but was last updated by hand; this keeps it in sync so the citation/metadata don't drift from `DESCRIPTION`. A per-commit `cm-skip` token in the commit message bypasses the run.

This is infrastructure unrelated to the sf-optional epic (#128/#129), so it's split out from #133 to be reviewable on its own.

## Test Plan

- Workflow triggers only on `push` to `main`/`master` when `DESCRIPTION` (or the workflow itself) changes, plus manual `workflow_dispatch`.
- Cannot exercise the push-and-commit path on a PR branch; it will run on first merge to `main`. The generation step (`codemetar::write_codemeta()`) is the standard r-lib pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)