### PR TITLE
Post-#135 cleanup: backwards-compat tests, geom_brain_sf() default fix, less nesting

### DIFF
--- a/R/geom-brain.R
+++ b/R/geom-brain.R
@@ -96,7 +96,7 @@ geom_brain_sf <- function(
   atlas,
   hemi = NULL,
   view = NULL,
-  position = new_position_brain(),
+  position = NULL,
   show.legend = NA,
   inherit.aes = TRUE,
   ...
@@ -110,6 +110,9 @@ geom_brain_sf <- function(
     )
   )
   require_sf("geom_brain_sf()")
+  if (is.null(position)) {
+    position <- make_position_brain_sf()
+  }
   dots <- list(...)
   if ("side" %in% names(dots)) {
     cli::cli_warn(c(

--- a/R/position-brain-polygon.R
+++ b/R/position-brain-polygon.R
@@ -239,7 +239,7 @@ frame_2_position_flat <- function(
   }
 
   df2 <- lapply(dfpos$data, gather_flat)
-  posi <- ifelse(length(dfpos$position) > 1, "grid", dfpos$position)
+  posi <- if (length(dfpos$position) > 1) "grid" else dfpos$position
 
   df3 <- switch(
     posi,

--- a/R/position-brain.R
+++ b/R/position-brain.R
@@ -164,7 +164,7 @@ position_brain_sf <- function(
     )
   )
   require_sf("position_brain_sf()")
-  new_position_brain(position, nrow = nrow, ncol = ncol, views = views)
+  make_position_brain_sf(position, nrow = nrow, ncol = ncol, views = views)
 }
 
 #' Construct a PositionBrain ggproto without the deprecation warning
@@ -172,7 +172,7 @@ position_brain_sf <- function(
 #' @keywords internal
 #' @noRd
 #' @importFrom ggplot2 ggproto
-new_position_brain <- function(
+make_position_brain_sf <- function(
   position = "horizontal",
   nrow = NULL,
   ncol = NULL,
@@ -331,10 +331,9 @@ position_cortical <- function(pos, chosen) {
     ))
   }
   if (any(grepl("+", pos, fixed = TRUE))) {
-    stacking_direction(pos)
-  } else {
-    chosen
+    chosen <- stacking_direction(pos)
   }
+  chosen
 }
 
 #' Resolve position for a subcortical/tract atlas formula
@@ -357,7 +356,11 @@ position_subcortical <- function(pos, chosen, data) {
     chosen
   }
 
-  list(position = position, chosen = chosen, data = data)
+  list(
+    position = position,
+    chosen = chosen,
+    data = data
+  )
 }
 
 
@@ -413,14 +416,13 @@ frame_2_position <- function(
     data$view <- as.character(data$view)
   }
 
+  dfpos <- split_data(data, pos)
   if (!is.null(nrow) || !is.null(ncol)) {
     dfpos <- split_data_grid(data, nrow, ncol)
-  } else {
-    dfpos <- split_data(data, pos)
   }
 
   df2 <- lapply(dfpos$data, gather_geometry)
-  posi <- ifelse(length(dfpos$position) > 1, "grid", dfpos$position)
+  posi <- if (length(dfpos$position) > 1) "grid" else dfpos$position
 
   df3 <- switch(
     posi,
@@ -493,46 +495,68 @@ split_data_grid <- function(data, nrow = NULL, ncol = NULL) {
 #' @noRd
 split_data <- function(data, position) {
   if (inherits(position, "formula")) {
-    pos <- position_formula(position, data)
-    if (!is.null(pos$data)) {
-      data <- pos$data
-    }
-    df2 <- dplyr::group_by_at(data, pos$chosen)
-    df2 <- dplyr::group_split(df2)
-    pos <- pos$position
+    split_data_formula(data, position)
   } else {
-    layout_direction <- "columns"
-    if (length(position) == 1) {
-      if (position %in% c("horizontal", "vertical")) {
-        layout_direction <- if (position == "vertical") "rows" else "columns"
-        position <- default_order(data)
-      }
-    }
-    pos <- as.data.frame(
-      strsplit(position, " ", fixed = TRUE),
-      stringsAsFactors = FALSE
-    )
-    atlas_type <- unique(data$type)[1]
-    if (atlas_type == "cortical") {
-      k <- cbind(
-        pos[2, ] %in% data$view,
-        pos[1, ] %in% data$hemi
-      )
-      k <- vapply(seq_len(nrow(k)), function(x) sum(k[x, ]), numeric(1))
-      pos <- pos[k == 2]
+    split_data_string(data, position)
+  }
+}
 
-      df2 <- lapply(pos, function(x) {
-        data[data$hemi == x[1] & data$view == x[2], ]
-      })
-    } else {
-      df2 <- lapply(pos, function(x) {
-        data[data$view == x, ]
-      })
-    }
-    pos <- layout_direction
+#' Split atlas data by a position formula (e.g. `hemi ~ view`)
+#'
+#' @return A list with `data` (one data.frame per group) and `position`
+#'   (the resolved layout direction or variable names).
+#' @keywords internal
+#' @noRd
+split_data_formula <- function(data, position) {
+  pos <- position_formula(position, data)
+  if (!is.null(pos$data)) {
+    data <- pos$data
+  }
+  groups <- dplyr::group_split(dplyr::group_by_at(data, pos$chosen))
+  list(data = groups, position = pos$position)
+}
+
+#' Split atlas data by a string layout
+#'
+#' `position` is either `"horizontal"`/`"vertical"` (expanded to the atlas's
+#' default view order) or pre-built `"hemi view"` / `"view"` identifiers.
+#'
+#' @inherit split_data_formula return
+#' @keywords internal
+#' @noRd
+split_data_string <- function(data, position) {
+  layout_direction <- "columns"
+  if (length(position) == 1 && position %in% c("horizontal", "vertical")) {
+    layout_direction <- if (position == "vertical") "rows" else "columns"
+    position <- default_order(data)
   }
 
-  list(data = df2, position = pos)
+  pos <- as.data.frame(
+    strsplit(position, " ", fixed = TRUE),
+    stringsAsFactors = FALSE
+  )
+
+  groups <- if (identical(unique(data$type)[1], "cortical")) {
+    split_cortical_pairs(data, pos)
+  } else {
+    lapply(pos, function(view) data[data$view == view, ])
+  }
+
+  list(data = groups, position = layout_direction)
+}
+
+#' Subset cortical data into its existing hemi/view pairs
+#'
+#' Columns of `pos` are `c(hemi, view)` pairs; keep only the pairs the atlas
+#' actually contains, then subset the data to each.
+#' @keywords internal
+#' @noRd
+split_cortical_pairs <- function(data, pos) {
+  has_pair <- (pos[1, ] %in% data$hemi) & (pos[2, ] %in% data$view)
+  pos <- pos[has_pair]
+  lapply(pos, function(pair) {
+    data[data$hemi == pair[1] & data$view == pair[2], ]
+  })
 }
 
 #' Zero-origin geometry for a single view

--- a/man/geom_brain_sf.Rd
+++ b/man/geom_brain_sf.Rd
@@ -10,7 +10,7 @@ geom_brain_sf(
   atlas,
   hemi = NULL,
   view = NULL,
-  position = new_position_brain(),
+  position = NULL,
   show.legend = NA,
   inherit.aes = TRUE,
   ...

--- a/tests/testthat/test-geom-brain-polygon.R
+++ b/tests/testthat/test-geom-brain-polygon.R
@@ -216,3 +216,27 @@ describe("brain_join_polygon() faceting", {
     expect_equal(unique(joined$group[joined$region %in% "insula"]), "cohort1")
   })
 })
+
+describe("geom_brain() backwards-compatibility with sf atlases", {
+  # The polygon flip kept geom_brain() working on atlas objects that pre-date
+  # the polygon representation: it decomposes their sf geometry on the fly.
+  # These lock that in so a later refactor can't silently break it.
+  it("renders a legacy ggseg_atlas object", {
+    skip_if_not_installed("sf")
+    legacy <- ggseg.formats::as_ggseg_atlas(dk())
+    expect_s3_class(legacy, "ggseg_atlas")
+    p <- ggplot2::ggplot() + geom_brain(atlas = legacy, show.legend = FALSE)
+    g <- ggplot2::ggplot_build(p)
+    expect_gt(nrow(g$data[[1]]), 0)
+  })
+
+  it("renders an sf-only atlas (no polygon representation)", {
+    skip_if_not_installed("sf")
+    sf_only <- ggseg.formats::as_sf_atlas(dk())
+    expect_true(ggseg.formats::is_atlas_sf(sf_only))
+    expect_false(ggseg.formats::is_atlas_polygon(sf_only))
+    p <- ggplot2::ggplot() + geom_brain(atlas = sf_only, show.legend = FALSE)
+    g <- ggplot2::ggplot_build(p)
+    expect_gt(nrow(g$data[[1]]), 0)
+  })
+})


### PR DESCRIPTION
Follow-up polish from reviewing the merged sf-optional epic (#135). No behaviour change to the public API.

## Changes

**Backwards-compatibility tests**
- Lock in that the public `geom_brain()` still renders a legacy `ggseg_atlas` object and an sf-only atlas (no polygon representation) — the polygon path decomposes their sf geometry on the fly. Insurance against the upcoming reposition consolidation (#136) silently breaking it.

**`geom_brain_sf()` default argument (CRAN / style)**
- It exposed a non-exported function as a default (`position = new_position_brain()`), which is poor form and surfaces an internal in the public `\usage`. Default is now `position = NULL`, resolved in the body.
- Renamed the internal `new_position_brain()` → the clearer `make_position_brain_sf()` (the old name read like a vctrs `new_*` constructor and clashed with `position_brain()`).

**Reduced nesting**
- `split_data()` is now a small dispatcher over `split_data_formula()` / `split_data_string()` / `split_cortical_pairs()`, removing several layers of if/else. Behaviour preserved (the `sum(...) == 2` pair filter becomes an equivalent `&`).
- Replaced two scalar `ifelse()` misuses with `if/else`.
- Left deliberately: `layer-brain.R` (deprecated sf-path ggproto, slated to go with `geom_brain_sf()`) and the Sutherland–Hodgman `clip_edge()` (nesting inherent to the algorithm).

## Test plan
- `R CMD check`: **0 errors, 0 warnings, 0 notes**.
- Full suite: **418 pass, 0 fail**, lint clean.

Related: #135 (merged epic), #136 (reposition de-duplication follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)