### PR TITLE
Unify sf + polygon view stacking onto one layout core (#136)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Imports:
     grid,
     lifecycle,
     rlang,
-    stats,
     tidyr (>= 1.0.0),
     utils
 Suggests:

--- a/R/position-brain-polygon.R
+++ b/R/position-brain-polygon.R
@@ -31,168 +31,6 @@ bbox_flat <- function(df) {
 }
 
 
-#' Translate flat coords so the bounding box starts at (0, 0)
-#'
-#' @param df Data.frame with `x`, `y` columns.
-#' @return Data.frame with shifted `x`, `y`.
-#' @keywords internal
-#' @noRd
-gather_flat <- function(df) {
-  b <- bbox_flat(df)
-  df$x <- df$x - b["xmin"]
-  df$y <- df$y - b["ymin"]
-  df
-}
-
-
-#' Center a view's flat coords within a grid cell
-#'
-#' Offsets `x`, `y` so the view is centered inside a cell of `cell_size`
-#' at position `grid_pos`.
-#'
-#' @param df Data.frame with `x`, `y` columns (already gathered to origin).
-#' @param cell_size Numeric length-2 `c(width, height)`.
-#' @param grid_pos Numeric length-2 `c(x, y)` offset.
-#' @return Data.frame with repositioned `x`, `y`.
-#' @keywords internal
-#' @noRd
-center_view_flat <- function(df, cell_size, grid_pos) {
-  b <- bbox_flat(df)
-  view_size <- c(b["xmax"] - b["xmin"], b["ymax"] - b["ymin"])
-  center_offset <- (cell_size - view_size) / 2
-  df$x <- df$x + grid_pos[1] + center_offset[1]
-  df$y <- df$y + grid_pos[2] + center_offset[2]
-  df
-}
-
-
-#' Cell separation for flat-coord stacking
-#'
-#' Determines x/y spacing between grid cells based on the maximum
-#' per-view bounding-box dimensions.
-#'
-#' @param data List of data.frames, each with `x`, `y` columns.
-#' @return Named numeric vector `c(x = ..., y = ...)`.
-#' @keywords internal
-#' @noRd
-get_sep_flat <- function(data) {
-  bboxes <- vapply(data, bbox_flat, numeric(4))
-  sep <- c(
-    max(bboxes["xmax", ]) - min(bboxes["xmin", ]),
-    max(bboxes["ymax", ]) - min(bboxes["ymin", ])
-  )
-  c("x" = sep[1] * 1.2, "y" = sep[2] * 1.2)
-}
-
-
-#' Stack flat-coord views horizontally
-#'
-#' @param df List of data.frames, each with `x`, `y` columns, already
-#'   gathered to origin by [gather_flat()].
-#' @return List with `df` (combined data.frame) and `box` (numeric bbox).
-#' @keywords internal
-#' @noRd
-stack_horizontal_flat <- function(df) {
-  sep <- get_sep_flat(df)
-  cell_size <- sep / 1.2
-
-  bx <- list()
-  for (k in seq_along(df)) {
-    df[[k]] <- center_view_flat(
-      df[[k]],
-      cell_size,
-      c((k - 1) * sep["x"], 0)
-    )
-    bx[[k]] <- bbox_flat(df[[k]])
-  }
-
-  list(df = dplyr::bind_rows(df), box = get_box_flat(bx))
-}
-
-
-#' Stack flat-coord views vertically
-#'
-#' @inheritParams stack_horizontal_flat
-#' @keywords internal
-#' @noRd
-stack_vertical_flat <- function(df) {
-  sep <- get_sep_flat(df)
-  cell_size <- sep / 1.2
-
-  bx <- list()
-  for (k in seq_along(df)) {
-    df[[k]] <- center_view_flat(
-      df[[k]],
-      cell_size,
-      c(0, (k - 1) * sep["y"])
-    )
-    bx[[k]] <- bbox_flat(df[[k]])
-  }
-
-  list(df = dplyr::bind_rows(df), box = get_box_flat(bx))
-}
-
-
-#' Stack flat-coord views on a row × column grid
-#'
-#' @param df List of data.frames, each with `x`, `y` columns and grid
-#'   assignment metadata.
-#' @param rows Column name identifying the row variable.
-#' @param columns Column name identifying the column variable.
-#' @keywords internal
-#' @noRd
-stack_grid_flat <- function(df, rows, columns) {
-  sep <- get_sep_flat(df)
-  lookup <- grid_lookup(df, rows, columns)
-
-  grid <- expand.grid(
-    col_idx = seq_along(lookup$col_vals),
-    row_idx = seq_along(lookup$row_vals)
-  )
-
-  cell_size <- sep / 1.2
-  df_positioned <- Map(
-    function(ri, ci) {
-      idx <- which(
-        lookup$df_rows == lookup$row_vals[ri] &
-          lookup$df_cols == lookup$col_vals[ci]
-      )
-      if (length(idx) != 1) {
-        return(NULL)
-      }
-      grid_pos <- c((ci - 1) * sep["x"], (ri - 1) * sep["y"])
-      center_view_flat(df[[idx]], cell_size, grid_pos)
-    },
-    grid$row_idx,
-    grid$col_idx
-  )
-
-  df_positioned <- Filter(Negate(is.null), df_positioned)
-  bx <- lapply(df_positioned, bbox_flat)
-  result_df <- drop_temp_columns(dplyr::bind_rows(df_positioned))
-
-  list(df = result_df, box = get_box_flat(bx))
-}
-
-
-#' Padded bounding box from a list of flat bboxes
-#'
-#' @param bx List of named numeric vectors with xmin/ymin/xmax/ymax.
-#' @return Named numeric vector `c(xmin, ymin, xmax, ymax)` with 1\% padding.
-#' @keywords internal
-#' @noRd
-get_box_flat <- function(bx) {
-  bx_mat <- do.call(rbind, bx)
-  pad <- max(bx_mat) * 0.01
-  c(
-    xmin = -pad,
-    ymin = -pad,
-    xmax = max(bx_mat[, "xmax"]) + pad,
-    ymax = max(bx_mat[, "ymax"]) + pad
-  )
-}
-
-
 #' Apply a position layout to flat polygon data
 #'
 #' Mirror of [frame_2_position()] for the polygon path. Operates on
@@ -238,18 +76,28 @@ frame_2_position_flat <- function(
     dfpos$data <- dfpos$data[keep]
   }
 
-  df2 <- lapply(dfpos$data, gather_flat)
   posi <- if (length(dfpos$position) > 1) "grid" else dfpos$position
+  rows <- if (posi == "grid") dfpos$position[1] else NULL
+  columns <- if (posi == "grid") dfpos$position[2] else NULL
 
-  df3 <- switch(
+  res <- position_groups(
+    dfpos$data,
     posi,
-    rows = stack_vertical_flat(df2),
-    columns = stack_horizontal_flat(df2),
-    grid = stack_grid_flat(df2, dfpos$position[1], dfpos$position[2])
+    rows,
+    columns,
+    bbox_of = bbox_flat,
+    translate = function(g, dx, dy) {
+      g$x <- g$x + dx
+      g$y <- g$y + dy
+      g
+    }
   )
 
-  out <- df3$df
-  attr(out, "polygon_bbox") <- df3$box
+  out <- dplyr::bind_rows(res$data)
+  if (posi == "grid") {
+    out <- drop_temp_columns(out)
+  }
+  attr(out, "polygon_bbox") <- res$box
   out
 }
 

--- a/R/position-brain.R
+++ b/R/position-brain.R
@@ -416,23 +416,36 @@ frame_2_position <- function(
     data$view <- as.character(data$view)
   }
 
-  dfpos <- split_data(data, pos)
   if (!is.null(nrow) || !is.null(ncol)) {
     dfpos <- split_data_grid(data, nrow, ncol)
+  } else {
+    dfpos <- split_data(data, pos)
   }
 
-  df2 <- lapply(dfpos$data, gather_geometry)
   posi <- if (length(dfpos$position) > 1) "grid" else dfpos$position
+  rows <- if (posi == "grid") dfpos$position[1] else NULL
+  columns <- if (posi == "grid") dfpos$position[2] else NULL
 
-  df3 <- switch(
+  res <- position_groups(
+    dfpos$data,
     posi,
-    rows = stack_vertical(df2),
-    columns = stack_horizontal(df2),
-    grid = stack_grid(df2, dfpos$position[1], dfpos$position[2])
+    rows,
+    columns,
+    bbox_of = function(g) as.numeric(sf::st_bbox(g$geometry)),
+    translate = function(g, dx, dy) {
+      g$geometry <- g$geometry + c(dx, dy)
+      g
+    }
   )
 
-  df4 <- sf::st_as_sf(df3$df)
-  attr(sf::st_geometry(df4), "bbox") <- df3$box
+  out <- do.call(rbind, res$data)
+  if (posi == "grid") {
+    out <- drop_temp_columns(out)
+  }
+  df4 <- sf::st_as_sf(out)
+  box <- res$box
+  class(box) <- "bbox"
+  attr(sf::st_geometry(df4), "bbox") <- box
 
   df4
 }
@@ -559,126 +572,6 @@ split_cortical_pairs <- function(data, pos) {
   })
 }
 
-#' Zero-origin geometry for a single view
-#'
-#' Translates geometry so the bounding box starts at (0, 0).
-#'
-#' @param df Data.frame with a `geometry` column.
-#'
-#' @return Modified data.frame with shifted geometry.
-#' @keywords internal
-#' @noRd
-gather_geometry <- function(df) {
-  bbx <- sf::st_bbox(df$geometry)
-  df$geometry <- df$geometry - bbx[c("xmin", "ymin")]
-  df
-}
-
-#' Center a view within a grid cell
-#'
-#' Offsets geometry so the view is centered inside a cell of
-#' `cell_size` at position `grid_pos`.
-#'
-#' @param df Data.frame with a `geometry` column.
-#' @param cell_size Numeric length-2 vector `c(width, height)`.
-#' @param grid_pos Numeric length-2 vector `c(x, y)` offset.
-#'
-#' @return Modified data.frame with repositioned geometry.
-#' @keywords internal
-#' @noRd
-center_view <- function(df, cell_size, grid_pos) {
-  bbox <- sf::st_bbox(df$geometry)
-  view_width <- bbox["xmax"] - bbox["xmin"]
-  view_height <- bbox["ymax"] - bbox["ymin"]
-  view_size <- c(view_width, view_height)
-  center_offset <- (cell_size - view_size) / 2
-  df$geometry <- df$geometry + grid_pos + center_offset
-  df
-}
-
-#' Arrange views in a horizontal row
-#'
-#' @param df List of data.frames, each with a `geometry` column.
-#'
-#' @return A list with `df` (combined data.frame) and `box` (bbox).
-#' @keywords internal
-#' @noRd
-stack_horizontal <- function(df) {
-  sep <- get_sep(df)
-  cell_size <- sep / 1.2
-
-  bx <- list()
-  for (k in seq_along(df)) {
-    df[[k]] <- center_view(df[[k]], cell_size, c((k - 1) * sep[1], 0))
-    bx[[k]] <- sf::st_bbox(df[[k]]$geometry)
-  }
-
-  list(df = do.call(rbind, df), box = get_box(bx))
-}
-
-#' Arrange views in a vertical column
-#'
-#' @param df List of data.frames, each with a `geometry` column.
-#'
-#' @return A list with `df` (combined data.frame) and `box` (bbox).
-#' @keywords internal
-#' @noRd
-stack_vertical <- function(df) {
-  sep <- get_sep(df)
-  cell_size <- sep / 1.2
-
-  bx <- list()
-  for (k in seq_along(df)) {
-    df[[k]] <- center_view(df[[k]], cell_size, c(0, (k - 1) * sep[2]))
-    bx[[k]] <- sf::st_bbox(df[[k]]$geometry)
-  }
-
-  list(df = do.call(rbind, df), box = get_box(bx))
-}
-
-#' Arrange views in a row-by-column grid
-#'
-#' @param df List of data.frames, each with a `geometry` column
-#'   and grid assignment columns.
-#' @param rows Column name identifying the row variable.
-#' @param columns Column name identifying the column variable.
-#'
-#' @return A list with `df` (combined data.frame) and `box` (bbox).
-#' @keywords internal
-#' @noRd
-stack_grid <- function(df, rows, columns) {
-  sep <- get_sep(df)
-  lookup <- grid_lookup(df, rows, columns)
-
-  grid <- expand.grid(
-    col_idx = seq_along(lookup$col_vals),
-    row_idx = seq_along(lookup$row_vals)
-  )
-
-  cell_size <- sep / 1.2
-  df_positioned <- Map(
-    function(ri, ci) {
-      idx <- which(
-        lookup$df_rows == lookup$row_vals[ri] &
-          lookup$df_cols == lookup$col_vals[ci]
-      )
-      if (length(idx) != 1) {
-        return(NULL)
-      }
-      grid_pos <- c((ci - 1) * sep[1], (ri - 1) * sep[2])
-      center_view(df[[idx]], cell_size, grid_pos)
-    },
-    grid$row_idx,
-    grid$col_idx
-  )
-
-  df_positioned <- Filter(Negate(is.null), df_positioned)
-  bx <- lapply(df_positioned, function(x) sf::st_bbox(x$geometry))
-  result_df <- drop_temp_columns(do.call(rbind, df_positioned))
-
-  list(df = result_df, box = get_box(bx))
-}
-
 #' Build a lookup of row/column values per data.frame element
 #'
 #' @param df List of data.frames from a split atlas.
@@ -732,44 +625,6 @@ drop_temp_columns <- function(df) {
     df[, temp] <- NULL
   }
   df
-}
-
-#' Compute a padded bounding box from a list of bboxes
-#'
-#' @param bx List of sf bbox objects.
-#'
-#' @return An sf `bbox` object with 1\% padding.
-#' @keywords internal
-#' @noRd
-get_box <- function(bx) {
-  bx <- do.call(rbind, bx)
-  pad <- max(bx) * 0.01
-  bx <- c(
-    -pad,
-    -pad,
-    max(bx[, "xmax"]) + pad,
-    max(bx[, "ymax"]) + pad
-  )
-  x <- stats::setNames(bx, c("xmin", "ymin", "xmax", "ymax"))
-  class(x) <- "bbox"
-  x
-}
-
-#' Compute cell separation distances
-#'
-#' Determines the x and y spacing between grid cells based on
-#' the maximum bounding-box dimensions across all views.
-#'
-#' @param data List of data.frames, each with a `geometry` column.
-#'
-#' @return Named numeric vector `c(x = ..., y = ...)`.
-#' @keywords internal
-#' @noRd
-get_sep <- function(data) {
-  get_bbox <- function(x) sf::st_bbox(x$geometry)
-  bboxes <- vapply(data, get_bbox, numeric(4))
-  sep <- c(max(bboxes[3, ]), max(bboxes[4, ]))
-  c("x" = sep[1] + sep[1] * 0.2, "y" = sep[2] + sep[2] * 0.2)
 }
 
 #' Generate the default view ordering for an atlas

--- a/R/position-layout.R
+++ b/R/position-layout.R
@@ -1,0 +1,111 @@
+# Shared, coordinate-agnostic view layout ----
+#
+# The sf path (position-brain.R) and the polygon path (position-brain-polygon.R)
+# arrange an atlas's view groups into a uniform grid with the *same* algorithm:
+# gather each group to the cell origin, centre it in a cell sized to the largest
+# group, and shift it to its grid position. That is a single translation per
+# group, derivable from the group's bounding box alone — so the math lives here
+# once and each path supplies only how to read a bbox and how to translate.
+
+#' Per-group `(dx, dy)` offsets that tile view groups into uniform cells
+#'
+#' Combines the three steps the old `gather_*` / `center_view*` / `stack_*`
+#' helpers did — gather to origin, centre in a uniform cell (sized to the
+#' largest group, +20\% separation), and shift to the `(row, col)` grid cell —
+#' into one translation per group. 1-D layouts pass a constant row or col index.
+#'
+#' @param bboxes Numeric matrix, one row per group, columns `xmin`, `ymin`,
+#'   `xmax`, `ymax`.
+#' @param row_idx,col_idx Integer 1-based cell indices, one per group.
+#' @return Numeric matrix with columns `dx`, `dy`, one row per group.
+#' @keywords internal
+#' @noRd
+layout_cell_offsets <- function(bboxes, row_idx, col_idx) {
+  w <- bboxes[, "xmax"] - bboxes[, "xmin"]
+  h <- bboxes[, "ymax"] - bboxes[, "ymin"]
+  cell_w <- max(w)
+  cell_h <- max(h)
+  sep_x <- cell_w * 1.2
+  sep_y <- cell_h * 1.2
+  cbind(
+    dx = -bboxes[, "xmin"] + (cell_w - w) / 2 + (col_idx - 1) * sep_x,
+    dy = -bboxes[, "ymin"] + (cell_h - h) / 2 + (row_idx - 1) * sep_y
+  )
+}
+
+
+#' Padded overall bounding box from per-group post-translation bboxes
+#'
+#' 1\% of the largest extent, anchored at the negative pad (matching the old
+#' `get_box()` / `get_box_flat()`).
+#'
+#' @param bboxes Numeric matrix of post-translation group bboxes.
+#' @return Named numeric `c(xmin, ymin, xmax, ymax)`.
+#' @keywords internal
+#' @noRd
+layout_box <- function(bboxes) {
+  pad <- max(bboxes) * 0.01
+  c(
+    xmin = -pad,
+    ymin = -pad,
+    xmax = max(bboxes[, "xmax"]) + pad,
+    ymax = max(bboxes[, "ymax"]) + pad
+  )
+}
+
+
+#' Resolve per-group cell indices and the row-major binding order
+#'
+#' @param groups List of per-view group data.frames.
+#' @param posi `"rows"`, `"columns"`, or `"grid"`.
+#' @param rows,columns Grid column names (grid mode only).
+#' @return List with integer `row`/`col` (per group) and `order` (row-major
+#'   bind order, dropping no groups — empty cells simply have no group).
+#' @keywords internal
+#' @noRd
+cell_indices <- function(groups, posi, rows = NULL, columns = NULL) {
+  n <- length(groups)
+  if (posi == "columns") {
+    return(list(row = rep(1L, n), col = seq_len(n), order = seq_len(n)))
+  }
+  if (posi == "rows") {
+    return(list(row = seq_len(n), col = rep(1L, n), order = seq_len(n)))
+  }
+  lookup <- grid_lookup(groups, rows, columns)
+  ri <- match(lookup$df_rows, lookup$row_vals)
+  ci <- match(lookup$df_cols, lookup$col_vals)
+  list(row = ri, col = ci, order = order(ri, ci))
+}
+
+
+#' Lay out view groups into uniform cells (sf- and polygon-agnostic)
+#'
+#' Shared driver for [frame_2_position()] (sf) and [frame_2_position_flat()]
+#' (polygon). Reads each group's bbox via `bbox_of`, computes the offsets with
+#' [layout_cell_offsets()], applies them via `translate`, and returns the groups
+#' in row-major bind order plus the padded overall box.
+#'
+#' @param groups List of per-view group objects.
+#' @param posi `"rows"`, `"columns"`, or `"grid"`.
+#' @param rows,columns Grid column names (grid mode only).
+#' @param bbox_of `function(group)` returning `c(xmin, ymin, xmax, ymax)`.
+#' @param translate `function(group, dx, dy)` returning the shifted group.
+#' @return List with `data` (translated groups, bind order) and `box`.
+#' @keywords internal
+#' @noRd
+position_groups <- function(groups, posi, rows, columns, bbox_of, translate) {
+  bboxes <- t(vapply(groups, bbox_of, numeric(4)))
+  colnames(bboxes) <- c("xmin", "ymin", "xmax", "ymax")
+
+  idx <- cell_indices(groups, posi, rows, columns)
+  offs <- layout_cell_offsets(bboxes, idx$row, idx$col)
+
+  moved <- lapply(seq_along(groups), function(i) {
+    translate(groups[[i]], offs[i, "dx"], offs[i, "dy"])
+  })
+  # post-translation bboxes: dx shifts xmin/xmax, dy shifts ymin/ymax
+  post <- bboxes + offs[, c("dx", "dy", "dx", "dy")]
+
+  ord <- idx$order
+  list(data = moved[ord], box = layout_box(post[ord, , drop = FALSE]))
+}

--- a/tests/testthat/test-position-brain-polygon.R
+++ b/tests/testthat/test-position-brain-polygon.R
@@ -51,21 +51,6 @@ describe("flat-coord helpers", {
     expect_named(b, c("xmin", "ymin", "xmax", "ymax"))
     expect_equal(unname(b), c(0, 0, 2, 2))
   })
-
-  it("gather_flat shifts bbox to origin", {
-    df <- data.frame(x = c(10, 12, 14), y = c(20, 22, 24))
-    out <- gather_flat(df)
-    expect_equal(min(out$x), 0)
-    expect_equal(min(out$y), 0)
-  })
-
-  it("center_view_flat preserves width/height while shifting position", {
-    df <- data.frame(x = c(0, 4), y = c(0, 2))
-    out <- center_view_flat(df, c(10, 10), c(100, 100))
-    expect_equal(diff(range(out$x)), 4)
-    expect_equal(diff(range(out$y)), 2)
-    expect_gt(min(out$x), 100)
-  })
 })
 
 describe("geom_brain_polygon() with position", {

--- a/tests/testthat/test-position-brain.R
+++ b/tests/testthat/test-position-brain.R
@@ -121,17 +121,6 @@ describe("split_data with subcortical", {
   })
 })
 
-describe("stack_vertical", {
-  it("stacks data frames vertically", {
-    skip_if_not_installed("sf")
-    data <- as.data.frame(dk())
-    split_result <- split_data(data, "vertical")
-    gathered <- lapply(split_result$data, gather_geometry)
-    result <- stack_vertical(gathered)
-    expect_type(result, "list")
-    expect_named(result, c("df", "box"))
-  })
-})
 
 describe("position_formula edge cases", {
   it("errors when formula missing '.' for single row/column", {

--- a/tests/testthat/test-position-layout.R
+++ b/tests/testthat/test-position-layout.R
@@ -1,0 +1,96 @@
+describe("layout_cell_offsets", {
+  it("gathers, centres in a uniform cell, and grid-shifts each group", {
+    # group 1 is 10x10 at origin; group 2 is 4x4 at origin
+    bboxes <- rbind(
+      c(xmin = 0, ymin = 0, xmax = 10, ymax = 10),
+      c(xmin = 0, ymin = 0, xmax = 4, ymax = 4)
+    )
+    offs <- layout_cell_offsets(bboxes, row_idx = c(1, 1), col_idx = c(1, 2))
+    # cell is 10x10 (largest), sep_x = 12
+    # g1: already fills the cell at origin -> no shift
+    expect_equal(unname(offs[1, ]), c(0, 0))
+    # g2: centred in the 10-wide cell ((10-4)/2 = 3) then +1 column (sep 12)
+    expect_equal(unname(offs[2, ]), c(3 + 12, 3))
+  })
+
+  it("shifts down the rows for a vertical layout", {
+    bboxes <- rbind(
+      c(xmin = 0, ymin = 0, xmax = 10, ymax = 10),
+      c(xmin = 0, ymin = 0, xmax = 10, ymax = 10)
+    )
+    offs <- layout_cell_offsets(bboxes, row_idx = c(1, 2), col_idx = c(1, 1))
+    expect_equal(unname(offs[, "dx"]), c(0, 0))
+    # second group drops one row; vertical separation is 12
+    expect_equal(unname(offs[, "dy"]), c(0, 12))
+  })
+
+  it("folds a non-zero origin into the offset (gather)", {
+    bboxes <- rbind(c(xmin = 100, ymin = 50, xmax = 110, ymax = 60))
+    offs <- layout_cell_offsets(bboxes, row_idx = 1, col_idx = 1)
+    expect_equal(unname(offs[1, ]), c(-100, -50))
+  })
+})
+
+describe("layout_box", {
+  it("pads the overall extent by 1% and anchors at the negative pad", {
+    bboxes <- rbind(
+      c(xmin = 0, ymin = 0, xmax = 10, ymax = 10),
+      c(xmin = 12, ymin = 0, xmax = 22, ymax = 10)
+    )
+    box <- layout_box(bboxes)
+    pad <- 22 * 0.01
+    expect_equal(unname(box), c(-pad, -pad, 22 + pad, 10 + pad))
+    expect_named(box, c("xmin", "ymin", "xmax", "ymax"))
+  })
+})
+
+describe("cell_indices", {
+  it("lays groups left-to-right for columns", {
+    groups <- vector("list", 3)
+    idx <- cell_indices(groups, "columns")
+    expect_equal(idx$row, c(1, 1, 1))
+    expect_equal(idx$col, c(1, 2, 3))
+    expect_equal(idx$order, 1:3)
+  })
+
+  it("stacks groups top-to-bottom for rows", {
+    groups <- vector("list", 3)
+    idx <- cell_indices(groups, "rows")
+    expect_equal(idx$row, c(1, 2, 3))
+    expect_equal(idx$col, c(1, 1, 1))
+  })
+
+  it("maps grid groups to (row, col) indices and returns row-major order", {
+    mk <- function(r, c) data.frame(.grid_row = r, .grid_col = c, x = 0, y = 0)
+    # indices are positions in the first-appearance unique values
+    groups <- list(mk(1, 1), mk(1, 2), mk(2, 1))
+    idx <- cell_indices(groups, "grid", ".grid_row", ".grid_col")
+    expect_equal(idx$row, c(1, 1, 2))
+    expect_equal(idx$col, c(1, 2, 1))
+    # already in row-major (row, col) order
+    expect_equal(idx$order, c(1, 2, 3))
+  })
+})
+
+describe("position_groups", {
+  it("applies the offsets via the supplied translate + returns padded box", {
+    g1 <- data.frame(x = c(0, 10), y = c(0, 10))
+    g2 <- data.frame(x = c(0, 10), y = c(0, 10))
+    res <- position_groups(
+      list(g1, g2),
+      "columns",
+      NULL,
+      NULL,
+      bbox_of = bbox_flat,
+      translate = function(g, dx, dy) {
+        g$x <- g$x + dx
+        g$y <- g$y + dy
+        g
+      }
+    )
+    expect_length(res$data, 2)
+    # second group shifted one cell to the right (sep_x = 12)
+    expect_equal(min(res$data[[2]]$x), 12)
+    expect_named(res$box, c("xmin", "ymin", "xmax", "ymax"))
+  })
+})


### PR DESCRIPTION
Implements the intra-ggseg consolidation from the #136 spike. **No behaviour change** — output is byte-identical.

## What

The sf path (`position-brain.R`) and polygon path (`position-brain-polygon.R`) implemented the *same* uniform-cell view layout twice — once over `sf::st_bbox` + geometry arithmetic, once over `range()` + `x`/`y`. Both reduce to a single translation per view group (gather to origin → centre in a uniform cell → shift to the grid cell), derivable from the group's bounding box alone.

- **New `R/position-layout.R`** — coordinate-agnostic core: `layout_cell_offsets()`, `layout_box()`, `cell_indices()`, and `position_groups()` (parametrised by a bbox reader + a translate fn).
- `frame_2_position()` (sf) and `frame_2_position_flat()` (polygon) now both call `position_groups()`. The sf path translates via `geometry + c(dx, dy)`; the polygon path via `x + dx` / `y + dy`.
- **Deleted 14 duplicated helpers**: `gather_geometry`, `center_view`, `stack_horizontal/vertical/grid`, `get_sep`, `get_box`, and their `*_flat` twins.
- Dropped now-unused `stats` from Imports (only `get_box` used `stats::setNames`).

## Why not consolidate with ggseg.formats

The spike (#136) showed the *stacking* differs between the packages (ggseg.formats packs tight; ggseg uses uniform cells for plotting), so the shared seam is intra-ggseg, not cross-package.

## Output identical — verified

- `reposition_brain()` vertices unchanged vs `main` (dk `hemi~view`, `view~hemi`, `horizontal`; aseg `horizontal`/`vertical`/`nrow`).
- All `brain-atlas-plots` + `annotate-brain` vdiffr snapshots pass unchanged.
- Replaced obsolete helper-unit tests with tests for the shared core.

## Test plan
- `R CMD check`: 0 errors, 0 warnings (local NOTE is the offline "future file timestamps" only).
- Full suite: **429 pass, 0 fail**; lint clean.
- Net **~250 fewer lines** of layout code.

Refs #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)