### PR TITLE
docs: CRAN prep — cran-comments + copyright holder alignment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2026
-COPYRIGHT HOLDER: Athanasia Mowinckel & Didac Vidal Pineiro
+COPYRIGHT HOLDER: Center for Lifespan Changes in Brain and Cognition, University of Oslo, Norway

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2018 Athanasia Mowinckel & Didac Vidal Pineiro
+Copyright (c) 2026 Center for Lifespan Changes in Brain and Cognition, University of Oslo, Norway
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,12 +2,27 @@
 
 0 errors | 0 warnings | 0 notes
 
-## Changes since last release (2.1.0 → 2.1.1)
+## Release summary
 
-* Fixed small ggplot2 internal import bug that caused downstream issues in other packages.
+This is a feature release (2.2.0). The headline change makes the 'sf' package
+an optional dependency: ggseg now draws brain atlases from a lightweight
+polygon representation by default, so it installs and plots on systems where
+'sf' (and its GDAL / GEOS / PROJ system libraries) is unavailable. The
+'sf'-backed rendering path remains available but is deprecated.
+
+## Dependency note
+
+ggseg imports 'ggseg.formats', which is on CRAN. This release relies on
+features in a newer 'ggseg.formats'; the 'Remotes' field will be removed and a
+minimum version pinned once that 'ggseg.formats' release is on CRAN.
 
 ## URL note
 
 The DOI URL <https://doi.org/10.1177/2515245920928009> returns HTTP 403
-because the publisher uses a captcha wall. The URL resolves correctly
-in a browser.
+because the publisher uses a captcha wall. The URL resolves correctly in a
+browser.
+
+## Reverse dependencies
+
+The downstream atlas packages in the ggsegverse were checked; final revdep
+results to be confirmed at submission time.


### PR DESCRIPTION
Small CRAN-readiness fixes from a `cran-extrachecks` audit (toward a future 2.2.0 submission).

- **cran-comments.md** rewritten for the 2.2.0 (sf-optional) release; kept the DOI-403 captcha note; added a note on the `ggseg.formats` dependency.
- **Copyright holder aligned**: `LICENSE` and `LICENSE.md` now name *Center for Lifespan Changes in Brain and Cognition, University of Oslo* — matching DESCRIPTION's `[cph]` (they previously named the individuals). Also bumped `LICENSE.md` year 2018 → 2026.

## Audit summary (for the record)
- ✅ All exported functions have `@return` + `@examples`; README clean; URLs https; Description well-formed with method DOI.
- ⚠️ **Submission blocker (not fixable here):** the `Remotes: ggsegverse/ggseg.formats` field must be removed before CRAN, which requires the newer `ggseg.formats` (with the polygon API this release uses) to be **released to CRAN first**, then pin `ggseg.formats (>= …)`.
- At submission: bump version `2.1.1.9001 → 2.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)