### PR TITLE
chore: CRAN prep 2.2.0 — depend on ggseg.formats (>= 0.0.3) directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg
 Title: Plotting Tool for Brain Atlases
-Version: 2.1.1.9001
+Version: 2.2.0
 Authors@R: c(
     person("Athanasia Mo", "Mowinckel", , "a.m.mowinckel@psykologi.uio.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5756-0223")),
@@ -27,7 +27,7 @@ Imports:
     cli,
     dplyr (>= 1.0.0),
     ggplot2 (>= 3.3),
-    ggseg.formats,
+    ggseg.formats (>= 0.0.3),
     grid,
     lifecycle,
     rlang,
@@ -44,8 +44,6 @@ Suggests:
     testthat (>= 3.0.0),
     vdiffr,
     withr
-Remotes:
-    ggsegverse/ggseg.formats
 VignetteBuilder:
     knitr
 Config/Needs/website: ggsegverse/ggseg.docs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ggseg 2.2.0 (development)
+# ggseg 2.2.0
 
 This release makes the **`sf` package optional**. ggseg now draws brains from a
 lightweight polygon representation by default, so it installs and plots even on

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -12,9 +12,9 @@ polygon representation by default, so it installs and plots on systems where
 
 ## Dependency note
 
-ggseg imports 'ggseg.formats', which is on CRAN. This release relies on
-features in a newer 'ggseg.formats'; the 'Remotes' field will be removed and a
-minimum version pinned once that 'ggseg.formats' release is on CRAN.
+This release relies on the sf-optional atlas format introduced in
+'ggseg.formats' 0.0.3, which is now on CRAN. The minimum version is pinned to
+'ggseg.formats (>= 0.0.3)' and the 'Remotes' field has been removed.
 
 ## URL note
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -17,6 +17,7 @@ Optimising
 PROJ
 Piñeiro
 PositionBrain
+Repositions
 Subcortical
 Tourville
 Visualise
@@ -24,6 +25,7 @@ WebAssembly
 aes
 aseg
 bankssts
+behaviour
 callosum
 cli
 colour
@@ -37,7 +39,6 @@ dk
 dkt
 doi
 dplyr
-eiro
 favour
 flamap
 freesurfer
@@ -65,7 +66,6 @@ postcentral
 pre
 precentral
 readme
-renderer
 reorganised
 repositioned
 roxygen
@@ -80,7 +80,6 @@ unlabelled
 vctrs
 vdiffr
 vis
-visualisation
 visualisations
 visualising
 vjust


### PR DESCRIPTION
## Summary

`ggseg.formats` 0.0.3 — the sf-optional atlas format — is now on CRAN, so ggseg can depend on it directly and ship 2.2.0.

- **DESCRIPTION**: bump to `2.2.0`, pin `ggseg.formats (>= 0.0.3)`, remove the `Remotes: ggsegverse/ggseg.formats` field.
- **NEWS.md**: finalise the 2.2.0 heading (drop `(development)`).
- **cran-comments.md**: update the dependency note now that 0.0.3 is on CRAN (min version pinned, Remotes removed).
- **inst/WORDLIST**: add `behaviour` / `Repositions` (new in 2.2.0 docs), prune 3 stale entries.

## Test plan

- Installed `ggseg.formats` 0.0.3 from source (CRAN's macOS arm64 *binary* still lags at 0.0.2) and confirmed all four functions ggseg imports — `as_polygon_atlas`, `atlas_geom`, `atlas_palette`, `atlas_polygons` — are exported.
- `R CMD check --as-cran` on the built `ggseg_2.2.0.tar.gz`: **0 errors | 0 warnings | 1 NOTE**, where the only NOTE ("HTML Tidy not recent enough") is a local-toolchain artefact that does not appear on CRAN's builders. The spelling NOTE was fixed via `spelling::update_wordlist()`.
- testthat suite passes within the check.

## Note

`codemeta.json` still reads `2.1.1.9001`; it's `.Rbuildignore`d and regenerated by the `update-codemeta` workflow via PR on merge to main, so left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)