### PR TITLE
chore: bump to development version 2.2.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg
 Title: Plotting Tool for Brain Atlases
-Version: 2.2.0
+Version: 2.2.0.9000
 Authors@R: c(
     person("Athanasia Mo", "Mowinckel", , "a.m.mowinckel@psykologi.uio.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5756-0223")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ggseg 2.2.0.9000 (development)
+
 # ggseg 2.2.0
 
 This release makes the **`sf` package optional**. ggseg now draws brains from a


### PR DESCRIPTION
Starts the next development cycle following the 2.2.0 CRAN release.

- **DESCRIPTION**: `2.2.0` → `2.2.0.9000`
- **NEWS.md**: add `# ggseg 2.2.0.9000 (development)` heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)