### PR TITLE
chore: bump to development version 2.2.1.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg
 Title: Plotting Tool for Brain Atlases
-Version: 2.2.1
+Version: 2.2.1.9000
 Authors@R: c(
     person("Athanasia Mo", "Mowinckel", , "a.m.mowinckel@psykologi.uio.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5756-0223")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ggseg 2.2.1.9000 (development)
+
 # ggseg 2.2.1
 
 - The test suite now builds its `sf` fixtures through the public atlas


### PR DESCRIPTION
## Summary

Post-release bump to the development version after 2.2.1 was accepted by CRAN.

- `DESCRIPTION`: `2.2.1` → `2.2.1.9000`
- `NEWS.md`: add `# ggseg 2.2.1.9000 (development)` header

## Test Plan

No code changes — version/NEWS only. CI must stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)