### PR TITLE
Use shared test-coverage reusable workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,3 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Badge approach from https://adamhsparks.netlify.app/2026/01/24/look-ma-no-codecov-io/
 on:
   push:
     branches: [main, master]
@@ -8,91 +6,10 @@ on:
 
 name: test-coverage
 
+permissions:
+  contents: write
+
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::covr
-          needs: coverage
-
-      - name: Test coverage
-        run: |
-          coverage <- covr::package_coverage(
-            quiet = FALSE,
-            commentDonttest = FALSE,
-            commentDontrun = FALSE
-          )
-          print(coverage)
-
-          percent_exact <- covr::percent_coverage(coverage)
-          percent <- floor(percent_exact)
-          cat("\nCoverage:", percent_exact, "% (rounded down to", percent, "%)\n")
-
-          if (percent >= 90) {
-            color <- "brightgreen"
-          } else if (percent >= 80) {
-            color <- "green"
-          } else if (percent >= 70) {
-            color <- "yellowgreen"
-          } else if (percent >= 60) {
-            color <- "yellow"
-          } else if (percent >= 50) {
-            color <- "orange"
-          } else {
-            color <- "red"
-          }
-
-          writeLines(as.character(percent), "coverage_percent.txt")
-          writeLines(color, "coverage_color.txt")
-        shell: Rscript {0}
-
-      - name: Generate coverage badge
-        run: |
-          COVERAGE=$(cat coverage_percent.txt)
-          COVERAGE_COLOR=$(cat coverage_color.txt)
-
-          echo "Coverage: $COVERAGE%"
-          echo "Color: $COVERAGE_COLOR"
-
-          mkdir -p badges
-          curl -s "https://raw.githubusercontent.com/pachadotdev/ghacoveragebadge/refs/heads/main/badges/${COVERAGE_COLOR}.svg" > badges/coverage.svg
-          sed -i "s/{{ COVERAGE }}/${COVERAGE}/g" badges/coverage.svg
-
-      - name: Commit coverage badge
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-          cp badges/coverage.svg /tmp/coverage.svg
-
-          git checkout -B coverage
-          git rm -rf . || true
-
-          mkdir -p badges
-          cp /tmp/coverage.svg badges/coverage.svg
-          git add badges/coverage.svg
-
-          if ! git diff --staged --quiet; then
-            git commit -m "Update coverage badge"
-            git push --force origin coverage
-          else
-            echo "No changes to commit"
-          fi
-
-          git checkout ${{ github.ref_name }}
+    uses: ggsegverse/.github/.github/workflows/test-coverage.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace the standalone `test-coverage.yaml` with a caller stub invoking the org-level badge-push reusable (`ggsegverse/.github`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)