### PR TITLE
ci: add dev-version-bump caller stub

### DIFF
--- a/.github/workflows/dev-version-bump.yaml
+++ b/.github/workflows/dev-version-bump.yaml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches: [main, master]
+    paths: [DESCRIPTION]
+  workflow_dispatch: # manual trigger, e.g. to backfill a missed dev bump
+
+name: dev-version-bump.yaml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dev-version-bump:
+    uses: ggsegverse/.github/.github/workflows/dev-version-bump.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the caller stub for the new `dev-version-bump` reusable workflow (`ggsegverse/.github/.github/workflows/dev-version-bump.yaml@main`).

After a release version is pushed to the default branch, it bumps `DESCRIPTION` to `x.y.z.9000`, prepends a NEWS "(development version)" heading, and opens a ggseg-bot PR that auto-merges. Watches `DESCRIPTION` only (mirrors the `release-on-version` stub), so it's inert until a real release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)