### PR TITLE
fix(geom_brain): inherit top-level data and aes in polygon renderer (#158)

### DIFF
--- a/.github/workflows/release-on-version.yaml
+++ b/.github/workflows/release-on-version.yaml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches: [main, master]
+    paths: [DESCRIPTION]
+  workflow_dispatch: # manual trigger, e.g. to backfill a missed release
+
+name: release-on-version.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ggsegverse/.github/.github/workflows/release-on-version.yaml@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg
 Title: Plotting Tool for Brain Atlases
-Version: 2.2.1.9000
+Version: 2.2.1.9001
 Authors@R: c(
     person("Athanasia Mo", "Mowinckel", , "a.m.mowinckel@psykologi.uio.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-5756-0223")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # ggseg 2.2.1.9000 (development)
 
+- `geom_brain()` again respects `data` and aesthetics set in the top-level
+  `ggplot()` call. The default polygon renderer built the atlas eagerly, before
+  the plot existed, so it never saw inherited `data`/`aes()` and fell back to
+  colouring by region label — e.g. `ggplot(df, aes(fill = value)) +
+geom_brain(atlas = dk())` errored with "Discrete value supplied to a
+  continuous scale". The atlas is now flattened and joined at plot-build time, so
+  inherited mappings, inherited data, and faceting all work (#158).
+
 # ggseg 2.2.1
 
 - The test suite now builds its `sf` fixtures through the public atlas

--- a/R/geom-brain-polygon.R
+++ b/R/geom-brain-polygon.R
@@ -62,31 +62,12 @@ geom_brain_polygon <- function(
   inherit.aes = TRUE,
   ...
 ) {
-  zoom_spec <- if (is_polygon_position(position)) position$zoom else NULL
-  focus <- resolve_zoom_focus(zoom_spec, data, atlas)
-
-  flat <- prepare_polygon_atlas(
-    atlas,
-    hemi = hemi,
-    view = view,
-    position = position,
-    context = context,
-    focus = focus
-  )
-
-  if (!is.null(data)) {
-    flat <- brain_join_polygon(data, flat)
-  }
-
   base_mapping <- aes(
     x = .data$x,
     y = .data$y,
     group = .data$.feature_id,
     subgroup = .data$subgroup
   )
-  if (!"fill" %in% names(mapping)) {
-    base_mapping$fill <- quote(.data$label)
-  }
   user_mapping <- utils::modifyList(base_mapping, as.list(mapping))
   class(user_mapping) <- "uneval"
 
@@ -98,14 +79,17 @@ geom_brain_polygon <- function(
     dots$linewidth <- 0.2
   }
 
-  layer <- rlang::exec(
-    geom_polygon,
+  layer <- layer_brain(
     mapping = user_mapping,
-    data = flat,
-    position = "identity",
+    data = data,
+    atlas = atlas,
+    hemi = hemi,
+    view = view,
+    position = position,
+    context = context,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
-    !!!dots
+    params = dots
   )
 
   result <- list(layer, coord_brain())
@@ -118,6 +102,146 @@ geom_brain_polygon <- function(
   }
 
   result
+}
+
+
+# ggplot2 does not export `Layer`, so we reach into its namespace once
+# to get the parent ggproto. Using `getFromNamespace()` rather than `:::`
+# keeps `R CMD check` clean. Defined here (the canonical polygon path)
+# because this file is sourced before layer-brain.R, whose `LayerBrainSf`
+# also subclasses it.
+ggplot2_Layer <- function() {
+  utils::getFromNamespace("Layer", "ggplot2")
+}
+
+#' Build a deferred brain-polygon layer
+#'
+#' Wraps [ggplot2::layer()] with the [LayerBrain] class and stashes the
+#' atlas and layout config on the layer object. The atlas is flattened and any
+#' user data joined at plot-build time (in `setup_layer()`), so the layer can
+#' see data and aesthetics inherited from the top-level `ggplot()` call.
+#'
+#' @keywords internal
+#' @noRd
+#' @importFrom ggplot2 GeomPolygon layer
+layer_brain <- function(
+  mapping,
+  data,
+  atlas,
+  hemi,
+  view,
+  position,
+  context,
+  show.legend,
+  inherit.aes,
+  params
+) {
+  brain_layer <- layer(
+    geom = GeomPolygon,
+    stat = "identity",
+    data = data,
+    mapping = mapping,
+    position = "identity",
+    show.legend = show.legend,
+    inherit.aes = inherit.aes,
+    params = params,
+    layer_class = LayerBrain
+  )
+  brain_layer$brain_atlas <- atlas
+  brain_layer$brain_hemi <- hemi
+  brain_layer$brain_view <- view
+  brain_layer$brain_position <- position
+  brain_layer$brain_context <- context
+  brain_layer
+}
+
+
+#' Custom ggplot2 Layer for the (default) sf-optional polygon path
+#'
+#' The canonical brain layer. Its `setup_layer()` runs at plot-build time, so it
+#' inherits the top-level `data` and aesthetic mapping: it flattens the atlas,
+#' joins inherited (or geom-level) data onto it, and only falls back to
+#' colouring by `label` when neither the layer nor the plot maps `fill`. Fixes
+#' ggsegverse/ggseg#158, where top-level `aes()`/`data` were dropped by the
+#' eager (construction-time) polygon build. The deprecated sf renderer has a
+#' parallel [LayerBrainSf].
+#'
+#' @keywords internal
+#' @noRd
+#' @importFrom ggplot2 ggproto ggproto_parent
+LayerBrain <- ggproto(
+  "LayerBrain",
+  ggplot2_Layer(),
+  setup_layer = function(self, data, plot) {
+    dt <- ggproto_parent(ggplot2_Layer(), self)$setup_layer(data, plot)
+
+    atlas <- self$brain_atlas
+    if (is.null(atlas)) {
+      cli::cli_abort(
+        "No atlas supplied, please provide a brain atlas to the geom."
+      )
+    }
+
+    has_data <- !inherits(dt, "waiver")
+
+    if (has_data && !dplyr::is.grouped_df(dt)) {
+      dt <- group_by_facet_vars(dt, plot, atlas)
+    }
+
+    zoom_spec <- if (is_polygon_position(self$brain_position)) {
+      self$brain_position$zoom
+    } else {
+      NULL
+    }
+    focus <- resolve_zoom_focus(zoom_spec, if (has_data) dt else NULL, atlas)
+
+    flat <- prepare_polygon_atlas(
+      atlas,
+      hemi = self$brain_hemi,
+      view = self$brain_view,
+      position = self$brain_position,
+      context = self$brain_context,
+      focus = focus
+    )
+
+    if (has_data) {
+      flat <- brain_join_polygon(dt, flat)
+    }
+
+    if (is.null(self$computed_mapping$fill)) {
+      self$computed_mapping$fill <- quote(.data$label)
+    }
+
+    flat
+  }
+)
+
+
+#' Auto-group user data by facet variables for atlas replication
+#'
+#' Parity with [LayerBrainSf]: when data is faceted but not explicitly grouped,
+#' group it by the facet variables so [brain_join_polygon()] replicates the full
+#' atlas once per panel. Facet variables that are atlas identity columns (e.g.
+#' `hemi`, `view`) are excluded -- faceting on those subsets the atlas rather
+#' than replicating it.
+#'
+#' @keywords internal
+#' @noRd
+group_by_facet_vars <- function(data, plot, atlas) {
+  facet_vars <- plot$facet$vars()
+  group_vars <- intersect(facet_vars, names(data))
+  atlas_cols <- unique(c(
+    names(atlas$core),
+    "view",
+    "type",
+    "atlas",
+    "hemi"
+  ))
+  group_vars <- setdiff(group_vars, atlas_cols)
+  if (length(group_vars) > 0) {
+    data <- dplyr::group_by(data, dplyr::across(dplyr::all_of(group_vars)))
+  }
+  data
 }
 
 

--- a/R/geom-brain.R
+++ b/R/geom-brain.R
@@ -126,7 +126,7 @@ geom_brain_sf <- function(
   }
 
   result <- list(
-    layer_brain(
+    layer_brain_sf(
       geom = GeomBrain,
       data = data,
       mapping = mapping,

--- a/R/layer-brain.R
+++ b/R/layer-brain.R
@@ -1,7 +1,8 @@
-#' Create a brain atlas ggplot2 layer
+#' Create an sf brain atlas ggplot2 layer (deprecated path)
 #'
 #' Thin wrapper around [ggplot2::layer()] that substitutes the
-#' custom [LayerBrain] class for atlas-specific setup logic.
+#' custom [LayerBrainSf] class for atlas-specific setup logic. Used by the
+#' deprecated [geom_brain_sf()]; the default polygon path uses [layer_brain()].
 #'
 #' @param geom A ggplot2 Geom ggproto object.
 #' @param stat A ggplot2 Stat ggproto object or string.
@@ -14,11 +15,11 @@
 #' @param check.param Whether to check parameters.
 #' @param show.legend Whether to include in legends.
 #'
-#' @return A [ggplot2::layer()] object of class `LayerBrain`.
+#' @return A [ggplot2::layer()] object of class `LayerBrainSf`.
 #' @importFrom ggplot2 layer
 #' @keywords internal
 #' @noRd
-layer_brain <- function(
+layer_brain_sf <- function(
   geom = NULL,
   stat = NULL,
   data = NULL,
@@ -41,31 +42,25 @@ layer_brain <- function(
     check.aes = check.aes,
     check.param = check.param,
     show.legend = show.legend,
-    layer_class = LayerBrain
+    layer_class = LayerBrainSf
   )
 }
 
-# ggplot2 does not export `Layer`, so we reach into its namespace once
-# to get the parent ggproto. Using `getFromNamespace()` rather than `:::`
-# keeps `R CMD check` clean.
-ggplot2_Layer <- function() {
-  utils::getFromNamespace("Layer", "ggplot2")
-}
-
-#' Custom ggplot2 Layer for brain atlas data
+#' Custom ggplot2 Layer for sf brain atlas data (deprecated path)
 #'
 #' A [ggplot2::ggproto()] Layer subclass that handles atlas
 #' validation, hemisphere/view filtering, data joining, and
 #' automatic aesthetic mapping in `setup_layer()`. Subclasses
-#' ggplot2's non-exported `Layer` ggproto via
-#' [utils::getFromNamespace()], avoiding `:::` usage.
+#' ggplot2's non-exported `Layer` ggproto via `ggplot2_Layer()`
+#' (defined in geom-brain-polygon.R). Parallel to the default
+#' polygon [LayerBrain].
 #'
 #' @importFrom utils capture.output getFromNamespace
 #' @importFrom ggplot2 ggproto ggproto_parent
 #' @keywords internal
 #' @noRd
-LayerBrain <- ggproto(
-  "LayerBrain",
+LayerBrainSf <- ggproto(
+  "LayerBrainSf",
   ggplot2_Layer(),
   setup_layer = function(self, data, plot) {
     dt <- ggproto_parent(ggplot2_Layer(), self)$setup_layer(data, plot)

--- a/R/position-brain-polygon.R
+++ b/R/position-brain-polygon.R
@@ -13,7 +13,7 @@
 # Layouts are applied at flatten time (inside prepare_polygon_atlas()) rather
 # than via a ggproto Position. That side-steps ggplot2's aesthetic-stripping
 # of non-standard columns (type / view / hemi), which the sf path's custom
-# LayerBrain avoids by declaring those columns as aesthetics.
+# LayerBrainSf avoids by declaring those columns as aesthetics.
 
 #' Bounding box of flat polygon coords
 #'

--- a/tests/testthat/test-geom-brain-polygon.R
+++ b/tests/testthat/test-geom-brain-polygon.R
@@ -226,14 +226,22 @@ describe("geom_brain() inherits top-level data and aes (ggseg#158)", {
     ggplot2::ggplot_build(p)$data[[1]]$fill
   }
 
-  it("uses a continuous fill mapped in ggplot(), not the region labels", {
-    mex <- data.frame(
+  # Adding a user fill scale on top of the atlas default emits an expected
+  # "Scale for fill is already present" message at plot-construction time.
+  labelled_values <- function() {
+    data.frame(
       label = ggseg.formats::atlas_labels(dk()),
       value = seq_along(ggseg.formats::atlas_labels(dk()))
     )
-    p <- ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
-      geom_brain(atlas = dk()) +
-      ggplot2::scale_fill_viridis_c()
+  }
+
+  it("uses a continuous fill mapped in ggplot(), not the region labels", {
+    mex <- labelled_values()
+    p <- suppressMessages(
+      ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
+        geom_brain(atlas = dk()) +
+        ggplot2::scale_fill_viridis_c()
+    )
     # The bug threw "Discrete value supplied to a continuous scale" at build.
     expect_no_error(fills <- fill_column(p))
     # A continuous scale resolves to many hex colours; unmatched context
@@ -244,16 +252,17 @@ describe("geom_brain() inherits top-level data and aes (ggseg#158)", {
   })
 
   it("matches the explicit geom-level data= workaround from the issue", {
-    mex <- data.frame(
-      label = ggseg.formats::atlas_labels(dk()),
-      value = seq_along(ggseg.formats::atlas_labels(dk()))
+    mex <- labelled_values()
+    inherited <- suppressMessages(
+      ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
+        geom_brain(atlas = dk()) +
+        ggplot2::scale_fill_viridis_c()
     )
-    inherited <- ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
-      geom_brain(atlas = dk()) +
-      ggplot2::scale_fill_viridis_c()
-    explicit <- ggplot2::ggplot() +
-      geom_brain(data = mex, atlas = dk(), ggplot2::aes(fill = value)) +
-      ggplot2::scale_fill_viridis_c()
+    explicit <- suppressMessages(
+      ggplot2::ggplot() +
+        geom_brain(data = mex, atlas = dk(), ggplot2::aes(fill = value)) +
+        ggplot2::scale_fill_viridis_c()
+    )
     expect_equal(fill_column(inherited), fill_column(explicit))
   })
 
@@ -265,21 +274,15 @@ describe("geom_brain() inherits top-level data and aes (ggseg#158)", {
 
   it("replicates the atlas per facet for inherited grouped-by-facet data", {
     mex <- rbind(
-      data.frame(
-        label = ggseg.formats::atlas_labels(dk()),
-        value = 1,
-        cohort = "A"
-      ),
-      data.frame(
-        label = ggseg.formats::atlas_labels(dk()),
-        value = 2,
-        cohort = "B"
-      )
+      cbind(labelled_values(), cohort = "A"),
+      cbind(labelled_values(), cohort = "B")
     )
-    p <- ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
-      geom_brain(atlas = dk()) +
-      ggplot2::facet_wrap(~cohort) +
-      ggplot2::scale_fill_viridis_c()
+    p <- suppressMessages(
+      ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
+        geom_brain(atlas = dk()) +
+        ggplot2::facet_wrap(~cohort) +
+        ggplot2::scale_fill_viridis_c()
+    )
     g <- ggplot2::ggplot_build(p)
     expect_setequal(unique(g$data[[1]]$PANEL), factor(c(1, 2)))
   })

--- a/tests/testthat/test-geom-brain-polygon.R
+++ b/tests/testthat/test-geom-brain-polygon.R
@@ -19,7 +19,9 @@ describe("geom_brain_polygon()", {
   it("errors when the atlas has no 2D geometry", {
     no_geom <- atlas_without_2d_geometry()
     expect_error(
-      ggplot2::ggplot() + geom_brain_polygon(atlas = no_geom),
+      ggplot2::ggplot_build(
+        ggplot2::ggplot() + geom_brain_polygon(atlas = no_geom)
+      ),
       "no 2D geometry"
     )
   })
@@ -35,7 +37,9 @@ describe("geom_brain_polygon()", {
   it("rejects invalid views with a clear error", {
     poly <- ggseg.formats::as_polygon_atlas(dk())
     expect_error(
-      ggplot2::ggplot() + geom_brain_polygon(atlas = poly, view = "nope"),
+      ggplot2::ggplot_build(
+        ggplot2::ggplot() + geom_brain_polygon(atlas = poly, view = "nope")
+      ),
       "Invalid view"
     )
   })
@@ -211,6 +215,73 @@ describe("brain_join_polygon() faceting", {
     joined <- brain_join_polygon(data, flat)
     expect_true("group" %in% names(joined))
     expect_equal(unique(joined$group[joined$region %in% "insula"]), "cohort1")
+  })
+})
+
+describe("geom_brain() inherits top-level data and aes (ggseg#158)", {
+  # Regression test for ggsegverse/ggseg#158: data and aesthetics set in the
+  # top-level ggplot() call were dropped by the eager polygon build, so fill
+  # fell back to the region labels instead of the user's mapped values.
+  fill_column <- function(p) {
+    ggplot2::ggplot_build(p)$data[[1]]$fill
+  }
+
+  it("uses a continuous fill mapped in ggplot(), not the region labels", {
+    mex <- data.frame(
+      label = ggseg.formats::atlas_labels(dk()),
+      value = seq_along(ggseg.formats::atlas_labels(dk()))
+    )
+    p <- ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
+      geom_brain(atlas = dk()) +
+      ggplot2::scale_fill_viridis_c()
+    # The bug threw "Discrete value supplied to a continuous scale" at build.
+    expect_no_error(fills <- fill_column(p))
+    # A continuous scale resolves to many hex colours; unmatched context
+    # regions keep the scale's grey na.value.
+    expect_gt(length(unique(grep("^#", fills, value = TRUE))), 2)
+    # Fill must not fall back to the region labels.
+    expect_false(any(fills %in% ggseg.formats::atlas_labels(dk())))
+  })
+
+  it("matches the explicit geom-level data= workaround from the issue", {
+    mex <- data.frame(
+      label = ggseg.formats::atlas_labels(dk()),
+      value = seq_along(ggseg.formats::atlas_labels(dk()))
+    )
+    inherited <- ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
+      geom_brain(atlas = dk()) +
+      ggplot2::scale_fill_viridis_c()
+    explicit <- ggplot2::ggplot() +
+      geom_brain(data = mex, atlas = dk(), ggplot2::aes(fill = value)) +
+      ggplot2::scale_fill_viridis_c()
+    expect_equal(fill_column(inherited), fill_column(explicit))
+  })
+
+  it("still colours by the atlas palette when no fill is mapped anywhere", {
+    p <- ggplot2::ggplot() + geom_brain(atlas = dk())
+    fills <- unique(fill_column(p))
+    expect_gt(length(fills), 2)
+  })
+
+  it("replicates the atlas per facet for inherited grouped-by-facet data", {
+    mex <- rbind(
+      data.frame(
+        label = ggseg.formats::atlas_labels(dk()),
+        value = 1,
+        cohort = "A"
+      ),
+      data.frame(
+        label = ggseg.formats::atlas_labels(dk()),
+        value = 2,
+        cohort = "B"
+      )
+    )
+    p <- ggplot2::ggplot(mex, ggplot2::aes(fill = value)) +
+      geom_brain(atlas = dk()) +
+      ggplot2::facet_wrap(~cohort) +
+      ggplot2::scale_fill_viridis_c()
+    g <- ggplot2::ggplot_build(p)
+    expect_setequal(unique(g$data[[1]]$PANEL), factor(c(1, 2)))
   })
 })
 

--- a/tests/testthat/test-geom-brain.R
+++ b/tests/testthat/test-geom-brain.R
@@ -201,14 +201,14 @@ describe("geom_brain faceting", {
   })
 })
 
-describe("LayerBrain", {
+describe("LayerBrainSf", {
   it("errors when no atlas is supplied", {
     skip_if_not_installed("sf")
     withr::local_options(lifecycle_verbosity = "quiet")
     expect_error(
       ggplot_build(
         ggplot() +
-          layer_brain(
+          layer_brain_sf(
             geom = GeomBrain,
             stat = "sf",
             position = position_brain_sf(),


### PR DESCRIPTION
## Summary

Fixes #158. On the default polygon renderer, `data` and aesthetics set in the top-level `ggplot()` call were dropped, so `geom_brain()` fell back to colouring by region label:

```r
ggplot(df, aes(fill = value)) + geom_brain(atlas = dk())
#> Error: Discrete value supplied to a continuous scale.
```

**Root cause:** `geom_brain_polygon()` built the atlas *eagerly* at construction time — before the plot existed — so it never saw inherited `data`/`aes()` and hard-set `fill = label`. The deprecated sf path (`geom_brain_sf`) worked because it defers this to a custom `Layer` whose `setup_layer()` runs at build time. This wasn't really Mac-specific — it's the polygon default in 2.2.x vs. an older sf-default install on Ubuntu.

**Fix:** the polygon path now uses the same architecture — a custom `LayerBrain` ggproto whose `setup_layer()` flattens the atlas, joins inherited (or geom-level) data, and only falls back to `fill = label` when neither the layer nor the plot maps `fill`. Faceting on inherited data auto-groups by facet vars so the atlas replicates per panel.

## Layer naming flip

Since the polygon path is canonical and the sf path is being deprecated:

| Role | Before | After |
|------|--------|-------|
| Polygon (default) layer | `geom_polygon` (eager) | **`LayerBrain`** / `layer_brain()` |
| sf (deprecated) layer | `LayerBrain` / `layer_brain()` | **`LayerBrainSf`** / `layer_brain_sf()` |

The shared `ggplot2_Layer()` helper moved to `geom-brain-polygon.R` (sourced first, so `LayerBrainSf` can subclass it). All these are internal (`@noRd`); the public API is unchanged (`document()` produced no NAMESPACE/man diff).

## Behaviour notes

- Atlas validation (no-geom / invalid view/hemi) now fires at `ggplot_build()` rather than construction — parity with the sf path. Two tests updated to build the plot.
- Known **pre-existing** shared quirk (not a regression, identical in `geom_brain_sf`): mapping `fill = region` at the plot level with no scale renders grey, because the auto-added `scale_fill_manual(atlas$palette)` is keyed by *label*. Left out of scope.

## Test plan

- [x] Verbatim issue example builds **and renders** a continuous viridis brain (matches the expected Ubuntu output).
- [x] Fixed polygon path is identical to `geom_brain_sf` across continuous / discrete / no-data / faceted cases.
- [x] Full suite: **435 passed, 0 failed**. Added 4 regression tests (#158) for inherited data/aes and faceting; updated 2 validation tests + sf-layer rename.
- [x] `air format` + `lintr` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)