### PR TITLE
fix(geom_brain): warn on user data that matches no atlas region (#121)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # ggseg 2.2.1.9000 (development)
 
+- `geom_brain()` again warns when rows of your `data` match no atlas region.
+  The default polygon renderer joins your data onto the atlas with a left join,
+  which silently dropped unmatched rows — so a mistyped or renamed region (e.g.
+  the short `"bankssts"` against the long region name) vanished without notice.
+  It now surfaces those rows with the same "Some data not merged properly"
+  warning the sf renderer gives (#121).
+
 - Internal geom/layer consolidation: the exported `GeomBrain` ggproto is now
   the polygon geom that backs the default `geom_brain()` (a `GeomPolygon`
   subclass). The deprecated sf renderer's geom was renamed to the internal

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,10 @@
 
 - `geom_brain()` again warns when rows of your `data` match no atlas region.
   The default polygon renderer joins your data onto the atlas with a left join,
-  which silently dropped unmatched rows — so a mistyped or renamed region (e.g.
-  the short `"bankssts"` against the long region name) vanished without notice.
-  It now surfaces those rows with the same "Some data not merged properly"
-  warning the sf renderer gives (#121).
+  which silently dropped unmatched rows — so a region name the atlas does not
+  use (e.g. the short `"bankssts"` against the long region name) vanished
+  without notice. It now surfaces those rows with the same "Some data not
+  merged properly" warning the sf renderer gives (#121).
 
 - Internal geom/layer consolidation: the exported `GeomBrain` ggproto is now
   the polygon geom that backs the default `geom_brain()` (a `GeomPolygon`

--- a/R/geom-brain-polygon.R
+++ b/R/geom-brain-polygon.R
@@ -376,6 +376,8 @@ brain_join_polygon <- function(data, flat) {
     ))
   }
 
+  warn_unmatched_polygon_data(data, flat, by)
+
   if (!dplyr::is.grouped_df(data)) {
     joined <- dplyr::left_join(flat, data, by = by, suffix = c("", ".user"))
     return(order_features_by_data(joined, data, by))
@@ -396,6 +398,38 @@ brain_join_polygon <- function(data, flat) {
     order_features_by_data(piece, nested$data[[i]], by)
   })
   dplyr::bind_rows(pieces)
+}
+
+
+#' Warn about user data rows that match no atlas region
+#'
+#' The polygon join keeps every atlas polygon and drops unmatched user rows
+#' (e.g. a mistyped or renamed region), so a mismatch would otherwise vanish
+#' silently. This mirrors the sf-path [brain_join()] warning so the dropped rows
+#' are surfaced (ggsegverse/ggseg#121). Grouping columns are ignored when
+#' detecting matches -- only the `by` keys (region/label/hemi) decide a match --
+#' so the unmatched rows are reported once across all groups.
+#'
+#' @param data The user data.frame (possibly grouped) being joined.
+#' @param flat The flattened atlas rows joined against.
+#' @param by Character vector of join columns.
+#' @return `invisible(NULL)`, called for its warning side effect.
+#' @keywords internal
+#' @noRd
+warn_unmatched_polygon_data <- function(data, flat, by) {
+  unmatched <- dplyr::anti_join(dplyr::ungroup(data), flat, by = by)
+  if (nrow(unmatched) == 0) {
+    return(invisible(NULL))
+  }
+  cli::cli_warn(c(
+    "Some data not merged properly.",
+    "i" = "Check for naming errors in {.arg data}:",
+    " " = paste(
+      utils::capture.output(print(dplyr::as_tibble(unmatched))),
+      collapse = "\n"
+    )
+  ))
+  invisible(NULL)
 }
 
 

--- a/tests/testthat/test-geom-brain-polygon.R
+++ b/tests/testthat/test-geom-brain-polygon.R
@@ -221,6 +221,63 @@ describe("brain_join_polygon() faceting", {
   })
 })
 
+describe("brain_join_polygon() warns on unmatched data (ggseg#121)", {
+  # The polygon join keeps every atlas polygon via a left join, so a data row
+  # that matches no region (a typo, or a name the atlas no longer uses -- e.g.
+  # the short "bankssts" against the long region label) was silently dropped.
+  # Restore the sf-path brain_join() warning so the mismatch surfaces.
+  poly <- ggseg.formats::as_polygon_atlas(dk())
+
+  it("warns when a data region matches no atlas region", {
+    flat <- prepare_polygon_atlas(poly)
+    data <- data.frame(region = c("bankssts", "insula"), p = c(0.9, 0.1))
+    expect_warning(brain_join_polygon(data, flat), "not merged")
+  })
+
+  it("names the unmatched value in the message", {
+    flat <- prepare_polygon_atlas(poly)
+    data <- data.frame(region = c("bankssts", "insula"), p = c(0.9, 0.1))
+    w <- expect_warning(brain_join_polygon(data, flat), "not merged")
+    expect_match(conditionMessage(w), "bankssts")
+    expect_no_match(conditionMessage(w), "insula")
+  })
+
+  it("stays silent when every data row matches", {
+    flat <- prepare_polygon_atlas(poly)
+    data <- data.frame(
+      region = c("banks of superior temporal sulcus", "insula"),
+      p = c(0.9, 0.1)
+    )
+    expect_no_warning(brain_join_polygon(data, flat))
+  })
+
+  it("matches by label without warning", {
+    flat <- prepare_polygon_atlas(poly)
+    data <- data.frame(label = c("lh_bankssts", "rh_bankssts"), p = c(0.9, 0.9))
+    expect_no_warning(brain_join_polygon(data, flat))
+  })
+
+  it("warns once for grouped data, not once per group", {
+    flat <- prepare_polygon_atlas(poly)
+    data <- dplyr::group_by(
+      data.frame(
+        region = c("bankssts", "insula"),
+        p = c(0.9, 0.1),
+        g = c("A", "B")
+      ),
+      g
+    )
+    expect_warning(brain_join_polygon(data, flat), "not merged")
+  })
+
+  it("surfaces the mismatch through a built plot", {
+    data <- data.frame(region = c("bankssts", "insula"), p = c(0.9, 0.1))
+    p <- ggplot2::ggplot(data) +
+      geom_brain(atlas = dk(), ggplot2::aes(fill = p))
+    expect_warning(ggplot2::ggplot_build(p), "not merged")
+  })
+})
+
 describe("geom_brain() inherits top-level data and aes (ggseg#158)", {
   # Regression test for ggsegverse/ggseg#158: data and aesthetics set in the
   # top-level ggplot() call were dropped by the eager polygon build, so fill


### PR DESCRIPTION
## Summary

The default (sf-optional) polygon renderer joins user data onto the atlas with a
**left join** (`brain_join_polygon()`), which keeps every atlas polygon and
silently **drops** any user row that matches no region. So a mistyped or renamed
region — most notably the short `"bankssts"` against the atlas's long
`"banks of superior temporal sulcus"` — vanished with no feedback (#121). The
deprecated sf renderer (`brain_join()`) warned in this case; the polygon path did
not.

This restores that warning: a new internal `warn_unmatched_polygon_data()` helper
uses an `anti_join()` on the join keys (`region`/`label`/`hemi`) to detect
unmatched rows **once across all groups**, and emits the same
`"Some data not merged properly"` warning the sf path gives.

This does **not** change what plots render — only whether the mismatch is
surfaced. #121 itself (the long `region` names living in **ggseg.formats**)
remains a separate data-side discussion; this just stops the mismatch being
silent.

## Test plan

New `describe("brain_join_polygon() warns on unmatched data (ggseg#121)")` block
in `test-geom-brain-polygon.R`:

- warns when a data region matches no atlas region
- names the unmatched value (`bankssts`) in the message, and not the matched one
- stays silent when every row matches (by full region name, and by `label`)
- warns once for grouped data, not once per group
- surfaces the mismatch through a built plot (`ggplot_build`)

Full test suite passes locally (sequential run); `document()` is a no-op (helper
is `@noRd`); `lintr` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)