### PR TITLE
fix(position_brain): ignore hemi for slice-based atlases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggseg 2.2.1.9000 (development)
 
+- `position_brain()` now ignores the `hemi` term (with a warning) for
+  slice-based atlases (subcortical, cerebellar, tract). Those views are whole
+  slices already containing both hemispheres, so `hemi ~ view` no longer splits
+  the grey-brain context into its own row away from the structures — each view
+  now renders with its anatomical context integrated, matching `plot()`.
+
 - New `brain_test_plot()` builds a minimal, deterministic atlas plot (regions
   filled by `label`, no legend, `theme_void()`) — the canonical construction for
   `vdiffr` snapshots across the ggsegverse, so a stray legend or title cannot

--- a/R/position-brain.R
+++ b/R/position-brain.R
@@ -309,6 +309,7 @@ position_formula <- function(pos, data) {
 
   if (atlas_type == "cortical") {
     position <- position_cortical(pos, chosen)
+    validate_stacking_formula(pos, position)
   } else {
     result <- position_subcortical(pos, chosen, data)
     position <- result$position
@@ -316,7 +317,6 @@ position_formula <- function(pos, data) {
     data <- result$data
   }
 
-  validate_stacking_formula(pos, position)
   list(position = position, chosen = chosen, data = data)
 }
 
@@ -350,9 +350,23 @@ position_cortical <- function(pos, chosen) {
 #' @keywords internal
 #' @noRd
 position_subcortical <- function(pos, chosen, data) {
+  if ("hemi" %in% chosen) {
+    cli::cli_warn(c(
+      "!" = "{.arg hemi} is ignored for slice-based atlases.",
+      "i" = "Subcortical, cerebellar and tract atlas views are whole slices \\
+             that already contain both hemispheres; laying out by \\
+             {.field view} only."
+    ))
+    chosen <- setdiff(chosen, "hemi")
+  }
+
   if ("type" %in% chosen) {
     data$.view_type <- extract_view_type(data$view)
     chosen[chosen == "type"] <- ".view_type"
+  }
+
+  if (length(chosen) == 0) {
+    chosen <- "view"
   }
 
   position <- if (length(chosen) == 1) {

--- a/R/position-brain.R
+++ b/R/position-brain.R
@@ -353,9 +353,7 @@ position_subcortical <- function(pos, chosen, data) {
   if ("hemi" %in% chosen) {
     cli::cli_warn(c(
       "!" = "{.arg hemi} is ignored for slice-based atlases.",
-      "i" = "Subcortical, cerebellar and tract atlas views are whole slices \\
-             that already contain both hemispheres; laying out by \\
-             {.field view} only."
+      "i" = "Slice-based atlas views already contain both hemispheres; {.arg hemi} will be dropped from the layout variables."
     ))
     chosen <- setdiff(chosen, "hemi")
   }

--- a/R/position-brain.R
+++ b/R/position-brain.R
@@ -353,7 +353,10 @@ position_subcortical <- function(pos, chosen, data) {
   if ("hemi" %in% chosen) {
     cli::cli_warn(c(
       "!" = "{.arg hemi} is ignored for slice-based atlases.",
-      "i" = "Slice-based atlas views already contain both hemispheres; {.arg hemi} will be dropped from the layout variables."
+      "i" = paste0(
+        "Slice-based atlas views already contain both hemispheres; ",
+        "{.arg hemi} will be dropped from the layout variables."
+      )
     ))
     chosen <- setdiff(chosen, "hemi")
   }

--- a/tests/testthat/test-position-brain.R
+++ b/tests/testthat/test-position-brain.R
@@ -261,11 +261,14 @@ describe("reposition_brain subcortical formula", {
 })
 
 describe("position_formula subcortical multi-var", {
-  it("handles two-variable formula for subcortical", {
+  it("ignores hemi for subcortical two-variable formulas", {
     data <- as.data.frame(aseg())
     data$hemi <- "left"
-    k <- position_formula(view ~ hemi, data)
-    expect_identical(k$position, c("view", "hemi"))
+    expect_warning(
+      k <- position_formula(view ~ hemi, data),
+      "hemi.*ignored"
+    )
+    expect_false("hemi" %in% k$chosen)
   })
 })
 
@@ -372,11 +375,15 @@ describe("position_subcortical", {
     expect_identical(result$position, "rows")
   })
 
-  it("returns chosen vars for two-var formula", {
+  it("drops hemi for a slice-based two-var formula", {
     data <- as.data.frame(aseg())
     data$hemi <- "left"
-    result <- position_subcortical(view ~ hemi, c("view", "hemi"), data)
-    expect_identical(result$position, c("view", "hemi"))
+    expect_warning(
+      result <- position_subcortical(view ~ hemi, c("view", "hemi"), data),
+      "hemi.*ignored"
+    )
+    expect_false("hemi" %in% result$chosen)
+    expect_identical(result$position, "columns")
   })
 })
 
@@ -415,5 +422,31 @@ describe("drop_temp_columns", {
     df <- data.frame(x = 1:3, y = 4:6)
     result <- drop_temp_columns(df)
     expect_identical(result, df)
+  })
+})
+
+describe("position_formula() with slice-based atlases", {
+  it("ignores hemi for subcortical atlases, laying out by view only", {
+    d <- as.data.frame(aseg())
+    expect_warning(
+      res <- position_formula(hemi ~ view, d),
+      "hemi.*ignored"
+    )
+    expect_false("hemi" %in% res$chosen)
+    expect_true("view" %in% res$chosen)
+  })
+
+  it("falls back to view when only hemi is supplied", {
+    d <- as.data.frame(aseg())
+    expect_warning(
+      res <- position_formula(hemi ~ ., d),
+      "hemi.*ignored"
+    )
+    expect_identical(res$chosen, "view")
+  })
+
+  it("does not warn about hemi for cortical atlases", {
+    d <- as.data.frame(dk())
+    expect_no_warning(position_formula(hemi ~ view, d))
   })
 })


### PR DESCRIPTION
## Summary

`position_brain(hemi ~ view)` was mis-laying-out **slice-based atlases** (subcortical, cerebellar, tract). Because their anatomical context — the `cortex` silhouette, brainstem, optic-chiasm — has `hemi = NA` while the structures are `left`/`right`, faceting by `hemi × view` shunted the grey brain into its own row, **divorced from the structures**. The nuclei rendered floating with no brain behind them.

A slice view already contains **both hemispheres**, so hemi-faceting is meaningless for these atlases. `position_subcortical()` now:
- **drops the `hemi` term** (with an informative warning) and lays out by `view` only, so each view renders with its context integrated — matching the base-R `plot()` method;
- moves the cortical-only stacking-formula validation into the cortical branch.

Cortical atlases are unaffected (`hemi ~ view` still facets by hemisphere).

### Before → after (thalamus, `hemi ~ view`)
Before: grey brain in a separate top row, nuclei floating in rows below.
After: each view is a full slice with the nuclei inside the grey brain.

## Test Plan

- [ ] R CMD check green
- New tests in `test-position-brain.R`: subcortical `hemi ~ view` warns + drops hemi; `hemi ~ .` falls back to `view`; cortical does not warn. Two tests that encoded the old (buggy) behaviour updated. 100 position tests pass locally.
- No subcortical vdiffr snapshot uses `hemi ~ view`, so no snapshots change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)